### PR TITLE
[FIX] GET /travel 속도 개선

### DIFF
--- a/src/controllers/travelController.ts
+++ b/src/controllers/travelController.ts
@@ -55,6 +55,23 @@ const makeTravel = async (req: Request, res: Response) => {
     }
 };
 
+const setTravelArray = async (travels, allTravels, name) => {
+    travels.map((t) => {
+        let memberNames = [];
+        t.members.map((name) => {
+            memberNames.push(name["name"]);
+        });
+        allTravels.get(name).push({
+            _id: t._id,
+            startDate: setTimeFormat(t.startDate),
+            endDate: setTimeFormat(t.endDate),
+            travelName: t.travelName,
+            image: t.image,
+            destination: t.destination,
+            members: memberNames
+        });
+    });
+};
 /**
  *  @route GET /travel
  *  @desc GET allTravel
@@ -88,54 +105,9 @@ const getTravel = async (req: Request, res: Response) => {
             allTravels.set(whenTravel[i], []);
         }
 
-        travels.nowTravels.map((t) => {
-            let memberNames = [];
-            t.members.map((name) => {
-                memberNames.push(name["name"]);
-            });
-            let nowTravelData = {
-                _id: t._id,
-                startDate: setTimeFormat(t.startDate),
-                endDate: setTimeFormat(t.endDate),
-                travelName: t.travelName,
-                image: t.image,
-                destination: t.destination,
-                members: memberNames
-            };
-            allTravels.get("nowTravels").push(nowTravelData);
-        });
-        travels.comeTravels.map((t) => {
-            let memberNames = [];
-            t.members.map((name) => {
-                memberNames.push(name["name"]);
-            });
-            let comeTravelData = {
-                _id: t._id,
-                startDate: setTimeFormat(t.startDate),
-                endDate: setTimeFormat(t.endDate),
-                travelName: t.travelName,
-                image: t.image,
-                destination: t.destination,
-                members: memberNames
-            };
-            allTravels.get("comeTravels").push(comeTravelData);
-        });
-        travels.endTravels.map((t) => {
-            let memberNames = [];
-            t.members.map((name) => {
-                memberNames.push(name["name"]);
-            });
-            let endTravelData = {
-                _id: t._id,
-                startDate: setTimeFormat(t.startDate),
-                endDate: setTimeFormat(t.endDate),
-                travelName: t.travelName,
-                image: t.image,
-                destination: t.destination,
-                members: memberNames
-            };
-            allTravels.get("endTravels").push(endTravelData);
-        });
+        setTravelArray(travels.nowTravels, allTravels, "nowTravels");
+        setTravelArray(travels.comeTravels, allTravels, "comeTravels");
+        setTravelArray(travels.endTravels, allTravels, "endTravels");
 
         const data = Array.from(allTravels, ([when, group]) => ({ when, group }));
 

--- a/src/services/mainService.ts
+++ b/src/services/mainService.ts
@@ -8,9 +8,11 @@ const findTravelByDate = async (data: userSearchInput) => {
         const user = await User.findOne({_id: data});
         const groupIds = user.groups;
 
-        const nowTravels = await Group.find({_id : {$in : groupIds}, startDate : {$lte : date}, endDate : {$gte : date}}).sort({startDate : 1}).populate("members", ["name"]);
-        const comeTravels = await Group.find({_id : {$in : groupIds}, startDate : {$gte : date}}).sort({startDate : 1}).populate("members", ["name"]);
-        const endTravels = await Group.find({_id : {$in : groupIds}, endDate : {$lte : date}}).sort({startDate : 1}).populate("members", ["name"]);
+        const [nowTravels, comeTravels, endTravels]= await Promise.all([
+            Group.find({ _id: { $in: groupIds }, startDate: { $lte: date }, endDate: { $gte: date } }).sort({ startDate: 1 }).populate("members", ["name"]),
+            Group.find({ _id: { $in: groupIds }, startDate: { $gte: date } }).sort({ startDate: 1 }).populate("members", ["name"]),
+            Group.find({ _id: { $in: groupIds }, endDate: { $lte: date } }).sort({ startDate: 1 }).populate("members", ["name"]),
+        ]); // 병렬 처리
 
         return {nowTravels, comeTravels, endTravels};
     } catch (error) {


### PR DESCRIPTION
### 관련 이슈
#169 

### 수정 내용
1. mainService.ts 내부에서 now, end, come 쿼리시 세개를 순차처리하지 않고 비동기 병렬 처리로 수정하여 속도를 880ms 정도로 개선하였습니다.
2. getTravel 함수 내에 map 3개가 반복된 로직이어서 재사용 가능한 함수로 만들어 처리하도록 수정했습니다.